### PR TITLE
docs: zero-to-hero README + protocol reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,24 +76,26 @@ print(f"Shared secret: {alice.secret.hex()}")
 
 ### One-way handshake (asymmetric trust)
 
-`HalfHandShake` derives the secret directly without XOR, for scenarios where only one party's contribution matters:
+`HalfHandShake` derives the secret directly without XOR, for scenarios where only one party's contribution matters. The sender chooses the secret and encrypts it with the receiver's public key; the receiver authenticates the sender and decrypts the secret. Only the receiver needs the sender's public key in advance:
 
 ```python
 from poorman_handshake import HalfHandShake
+from secrets import compare_digest
 
-server = HalfHandShake()
-client = HalfHandShake()
+sender = HalfHandShake()
+receiver = HalfHandShake()
 
-client.load_public(server.pubkey)
+# The receiver holds the sender's public key (exchanged securely beforehand)
+receiver.load_public(sender.pubkey)
 
-# Client generates handshake
-client_shake = client.generate_handshake()
+# The sender encrypts its secret with the receiver's public key
+sender_shake = sender.generate_handshake(receiver.pubkey)
 
-# Server receives and derives the client's secret directly
-server.receive_and_verify(client_shake)
+# The receiver verifies the sender's signature and decrypts the secret
+receiver.receive_and_verify(sender_shake)
 
-# Both hold the same key (derived from client's secret only)
-assert compare_digest(server.secret, client.secret)
+# Both hold the same key (chosen by the sender)
+assert compare_digest(receiver.secret, sender.secret)
 ```
 
 ## API Reference
@@ -163,9 +165,9 @@ Low-level RSA operations in `poorman_handshake.asymmetric.utils`:
 Low-level PAKE operations in `poorman_handshake.symmetric.utils`:
 
 - `generate_iv(key_length=8) -> bytes`: Generate a random 64-bit IV.
-- `create_hsub(password, iv=None, hsublen=48) -> str`: Create a hex-encoded hashed subject (hsub).
-- `match_hsub(hsub, password) -> bool`: Verify an hsub against a password.
-- `iv_from_hsub(hsub) -> bytes`: Extract IV from an hsub.
+- `create_hsub(text, iv=None, hsublen=48) -> str`: Create a hex-encoded hashed subject (hsub) from the shared secret `text`.
+- `match_hsub(hsub, subject) -> bool`: Verify an hsub against the shared secret `subject`.
+- `iv_from_hsub(hsub, digits=16) -> bytes`: Extract the IV from an hsub.
 
 ## Examples
 
@@ -176,6 +178,12 @@ See the [examples](./examples) folder for additional use cases:
 - `half_handshake.py`: One-way key agreement.
 - `poor_pake.py`: Password-based key exchange.
 - `*_mitm.py` demos: Man-in-the-middle attack illustrations.
+
+## Deeper reference
+
+[`docs/protocol.md`](./docs/protocol.md) walks through how each variant derives
+its shared secret, the TOFU and pre-distributed-key trust models, the low-level
+RSA helpers, and where the handshake fits in the HiveMind connection flow.
 
 ## Security Notes
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,122 @@
+# Handshake protocol reference
+
+This page documents how the three handshake variants in `poorman_handshake`
+derive a shared secret, and where each fits in the HiveMind mesh. For the
+quickstart and API surface, see the [README](../README.md).
+
+## Where this sits in HiveMind
+
+A HiveMind satellite and the [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)
+hub establish an encrypted channel before exchanging any bus traffic. The
+shared secret produced by a handshake here is the input to that channel's
+authenticated symmetric encryption. The access key handed out by
+`hivemind-core add-client` is the pre-shared password consumed by the
+password path below.
+
+## Symmetric path — `PasswordHandShake`
+
+A PAKE-style exchange: both parties already share a password and want a
+symmetric key without ever sending the password over the wire.
+
+1. Each party generates a random 64-bit IV (`generate_iv`).
+2. Each derives a **hsub** (hashed subject) binding the IV to the password
+   (`create_hsub`) and sends it as the handshake message.
+3. On receipt, each party extracts the peer's IV (`iv_from_hsub`) and verifies
+   the hsub against the shared password (`match_hsub`). A mismatch means the
+   peer does not hold the password — the handshake is rejected.
+4. The two IVs are XORed into a common salt, and the final key is derived with
+   PBKDF2-HMAC-SHA256 over the password and that salt.
+
+Because the salt mixes both IVs, neither side alone fixes the key, and the
+password itself never travels.
+
+```python
+from poorman_handshake import PasswordHandShake
+from secrets import compare_digest
+
+a = PasswordHandShake("shared access key")
+b = PasswordHandShake("shared access key")
+ha, hb = a.generate_handshake(), b.generate_handshake()
+assert a.receive_and_verify(hb) and b.receive_and_verify(ha)
+assert compare_digest(a.secret, b.secret)
+```
+
+## Asymmetric path — `HandShake`
+
+Mutual RSA key agreement where **both** parties contribute randomness, so a
+single compromised party cannot dictate the key.
+
+1. Each party owns an RSA keypair (generated, or loaded from a PEM file via the
+   `path` constructor argument for a stable identity).
+2. Public keys are exchanged out of band and loaded with `load_public`.
+3. Each party picks a random secret, signs it (RSA-PSS), encrypts it to the
+   peer's public key (RSA-OAEP), and sends the concatenation as the handshake.
+4. `receive_and_verify` checks the signature against the peer's public key,
+   decrypts the peer's secret, and XORs it with the locally chosen secret.
+
+The final `secret` is the XOR of both contributions, so it is identical on both
+ends and depends on input from each.
+
+```python
+from poorman_handshake import HandShake
+from secrets import compare_digest
+
+a, b = HandShake(), HandShake()
+a.load_public(b.pubkey); b.load_public(a.pubkey)
+ha, hb = a.generate_handshake(), b.generate_handshake()
+a.receive_and_verify(hb); b.receive_and_verify(ha)
+assert compare_digest(a.secret, b.secret)
+```
+
+### One-way — `HalfHandShake`
+
+Subclass of `HandShake` for asymmetric trust: the **sender** chooses the secret
+and the **receiver** authenticates the sender. Only the sender's contribution
+is used (no XOR), so only the receiver needs the sender's public key in
+advance.
+
+```python
+from poorman_handshake import HalfHandShake
+from secrets import compare_digest
+
+sender, receiver = HalfHandShake(), HalfHandShake()
+receiver.load_public(sender.pubkey)            # sender pubkey known to receiver
+shake = sender.generate_handshake(receiver.pubkey)
+receiver.receive_and_verify(shake)
+assert compare_digest(receiver.secret, sender.secret)
+```
+
+## Identity and trust models
+
+`HandShake(path=...)` loads or creates a persistent private key, giving a node a
+stable public identity across restarts. With stable keys you can layer a trust
+model on top of the raw exchange:
+
+- **TOFU (trust on first use)** — pin a peer's public key the first time it is
+  seen and reject changes thereafter. See `examples/tofu_handshake.py`.
+- **Pre-distributed keys** — ship known public keys out of band and refuse
+  unknown peers. See `examples/static_handshake.py`.
+
+The `examples/*_mitm.py` scripts demonstrate why out-of-band public-key
+validation matters: without it, an attacker who can relay messages can sit
+between two parties. The signature step prevents tampering, but only if each
+side already knows the other's authentic public key.
+
+## Low-level RSA helpers
+
+`poorman_handshake.asymmetric.utils` exposes the primitives the handshake is
+built from, usable directly for ad-hoc encryption or signing:
+
+- `encrypt_RSA` / `decrypt_RSA` — RSA-OAEP for short payloads.
+- `hybrid_encrypt_RSA` / `hybrid_decrypt_RSA` — RSA-wrapped AES-GCM for
+  arbitrary-length payloads.
+- `sign_RSA` / `verify_RSA` — RSA-PSS signatures.
+- `load_RSA_key` / `export_RSA_key` / `create_RSA_key` — PEM key management.
+
+## Security caveats
+
+This library is the bootstrap primitive, not a full secure-transport stack.
+The derived `secret` must be used with authenticated encryption (AES-GCM,
+ChaCha20-Poly1305), public-key distribution must be validated out of band, and
+the PBKDF2 iteration count, RSA key size, and OAEP/PSS parameters should be
+reviewed before use outside HiveMind.


### PR DESCRIPTION
Fixes the one-way `HalfHandShake` example (the sender chooses and encrypts the secret to the receiver's public key; the previous example's direction did not run) and tightens the low-level hsub helper signatures to match the code. Adds `docs/protocol.md` describing how each variant derives its shared secret, the TOFU / pre-distributed-key trust models, the RSA helpers, and where the handshake sits in the HiveMind connection flow.

All README/doc code examples were executed against the library to confirm they run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)