### PR TITLE
docs: security analysis of the handshake constructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Poor Man's Handshake
 
-Securely exchange symmetric encryption keys over insecure channels using either password-based or RSA public-key handshakes. This library provides the cryptographic bootstrap primitive for the HiveMind distributed mesh — nodes use it to establish a shared session secret before raising an encrypted channel.
+Securely exchange symmetric encryption keys over insecure channels using a Noise-framework handshake or the legacy password / RSA handshakes. This library provides the cryptographic bootstrap primitive for the HiveMind distributed mesh — nodes use it to establish a shared session secret before raising an encrypted channel.
+
+> **Which handshake should I use?** The **Noise handshake** (`NoiseHandShake`) is the recommended path: it adds forward secrecy, PAKE-grade password authentication (no offline-crackable image on the wire), replay resistance, and downgrade protection that the password and RSA handshakes lack. The legacy handshakes remain for interoperability with existing deployments. See [`docs/security.md`](docs/security.md) for the full analysis of why.
 
 ## Features
 
-- **Password-based key exchange** (`PasswordHandShake`): Derive a shared symmetric key from a pre-shared password without ever transmitting the password. Each party generates a random IV, hashes it with the password, and XORs the IVs to form a common salt. The final key is derived via PBKDF2-HMAC-SHA256.
+- **Noise handshake** (`NoiseHandShake`): A [Noise Protocol Framework](https://noiseprotocol.org/) authenticated key exchange (`Noise_XXpsk2` / `Noise_KKpsk0` over X25519 + ChaCha20-Poly1305 + SHA-256). The shared password enters as the Noise PSK — never as an on-wire image — and session keys come from an ephemeral X25519 exchange, giving **forward secrecy**, **PAKE-grade** password authentication, per-message **replay resistance**, and prologue-bound **downgrade protection**. Static keys are learned during `XX` for trust-on-first-use pinning. This is HiveMind protocol v3.
+- **Password-based key exchange** (`PasswordHandShake`): Derive a shared symmetric key from a pre-shared password without ever transmitting the password. Each party generates a random IV, hashes it with the password, and XORs the IVs to form a common salt. The final key is derived via PBKDF2-HMAC-SHA256. Note: the on-wire verifier is an offline-crackable image of the password (safe only with a high-entropy secret) — prefer `NoiseHandShake`.
 - **RSA public-key exchange** (`HandShake`): Mutual RSA key agreement where both parties contribute a random secret. The secrets are XORed to form the final shared key, ensuring both contributions are needed.
 - **Asymmetric exchange** (`HalfHandShake`): One-way key agreement for asymmetric trust scenarios (only one party's secret is used).
 - **Hybrid RSA+AES-GCM encryption**: Arbitrary-length plaintext support via RSA-encrypted AES keys.
@@ -16,9 +19,40 @@ Securely exchange symmetric encryption keys over insecure channels using either 
 pip install poorman_handshake
 ```
 
-Requires Python 3.10+ and `pycryptodomex >= 3.19.1`.
+Requires Python 3.10+, `pycryptodomex >= 3.19.1`, `noiseprotocol >= 0.3.1`, and `argon2-cffi >= 21.3.0` (all installed automatically).
 
 ## Quick Start
+
+### Noise handshake (recommended)
+
+Both peers share a site *password*; the connecting node initiates. The default
+`XXpsk2` pattern needs no prior knowledge of the peer's static key — each side
+learns and can pin it during the exchange.
+
+```python
+from poorman_handshake.noise import NoiseHandShake
+
+# alice = connecting node (initiator); bob = server (responder).
+# node_id is the server's id, used as the PSK derivation salt.
+alice = NoiseHandShake(initiator=True, password="site-password", node_id="server-01")
+bob = NoiseHandShake(initiator=False, password="site-password", node_id="server-01")
+
+# XXpsk2 is three messages, exchanged over any insecure channel (no TLS needed):
+bob.read_message(alice.write_message())    # msg 1: e
+alice.read_message(bob.write_message())    # msg 2: e, ee, s, es, psk
+bob.read_message(alice.write_message())    # msg 3: s, se
+
+assert alice.handshake_finished and bob.handshake_finished
+assert alice.remote_pubkey == bob.pubkey_bytes   # learned static key — pin it (TOFU)
+
+# Encrypted session: per-message counter nonces make replays fail to decrypt.
+ciphertext = alice.encrypt(b"hello over the mesh")
+assert bob.decrypt(ciphertext) == b"hello over the mesh"
+```
+
+Pre-provisioned peers (both static keys known in advance) select the two-message
+`KKpsk0` pattern automatically by passing `remote_pubkey=`. See
+[`examples/noise_kk.py`](examples/noise_kk.py).
 
 ### Password-based handshake
 
@@ -100,9 +134,51 @@ assert compare_digest(receiver.secret, sender.secret)
 
 ## API Reference
 
+### `NoiseHandShake`
+
+Noise-framework authenticated key exchange (HiveMind protocol v3). Recommended.
+
+**Constructor:**
+```python
+NoiseHandShake(
+    initiator: bool,
+    path: str = None,
+    password: str | bytes = None,
+    node_id: str | bytes = None,
+    psk: bytes = None,
+    remote_pubkey: str | bytes = None,
+    prologue: bytes = b"",
+    pattern: bytes = None,
+)
+```
+- `initiator`: `True` for the connecting side, `False` for the responder.
+- `path`: Optional file to load/persist the static X25519 key (generated if absent).
+- `password` / `node_id`: Shared password, stretched into the 32-byte PSK with argon2id salted by `SHA-256(node_id)`. Provide either this pair or `psk`.
+- `psk`: A pre-derived 32-byte pre-shared key (alternative to `password`).
+- `remote_pubkey`: Peer static public key (hex or 32 raw bytes). Supplying it selects `KKpsk0`; omitting it uses `XXpsk2` (learn-and-pin).
+- `prologue`: Bytes bound into the handshake hash for downgrade protection; both sides must supply identical bytes. Encode the negotiated protocol version and cipher/encoding lists here.
+- `pattern`: Override the Noise protocol name (defaults per `remote_pubkey`).
+
+**Methods:**
+- `write_message(payload: bytes = b"") -> bytes`: Produce the next handshake message (or, once finished, a transport message).
+- `read_message(data: bytes) -> bytes`: Consume the peer's next message.
+- `split() -> (send, recv)`: The two transport `CipherState`s after the handshake.
+- `encrypt(data: bytes) -> bytes` / `decrypt(data: bytes) -> bytes`: Transport encryption using the split CipherStates (per-message counter nonces → replay resistant).
+- `load_private(path)` / `export_private_key(path)`: Static-key persistence.
+
+**Properties:**
+- `handshake_finished: bool`: Whether the handshake is complete.
+- `pubkey: str` / `pubkey_bytes: bytes`: This node's static public key.
+- `remote_pubkey: bytes | None`: The peer's static public key (learned during `XX`); pin it for TOFU.
+- `handshake_hash: bytes | None`: Shared transcript fingerprint for channel binding.
+
+### `derive_psk(password, node_id=None, salt=None) -> bytes`
+
+Derive a 32-byte Noise PSK from a password using argon2id. The salt defaults to `SHA-256(node_id)` (per HIVEMIND-CRYPTO-1) when `node_id` is given. Both peers must derive with identical inputs.
+
 ### `PasswordHandShake`
 
-Password-based authenticated key agreement (PAKE-like).
+Password-based key agreement. **Not a PAKE** — the handshake transmits a salted-hash *verifier* of the password, which a passive observer can attack offline; it is safe only with a high-entropy shared secret. For a low-entropy password, use `NoiseHandShake` instead (see [`docs/security.md`](docs/security.md)).
 
 **Constructor:**
 ```python
@@ -172,6 +248,8 @@ Low-level PAKE operations in `poorman_handshake.symmetric.utils`:
 ## Examples
 
 See the [examples](./examples) folder for additional use cases:
+- `noise_handshake.py`: Noise `XXpsk2` password handshake with TOFU key learning (**recommended**).
+- `noise_kk.py`: Noise `KKpsk0` handshake with pre-provisioned static keys.
 - `simple_handshake.py`: Basic RSA handshake.
 - `static_handshake.py`: Persistent key file handshake.
 - `tofu_handshake.py`: Trust-on-first-use (TOFU) key pinning.
@@ -185,13 +263,19 @@ See the [examples](./examples) folder for additional use cases:
 its shared secret, the TOFU and pre-distributed-key trust models, the low-level
 RSA helpers, and where the handshake fits in the HiveMind connection flow.
 
+[`docs/security.md`](./docs/security.md) is the threat-model analysis: what each
+construction protects against and what it does not, why the password and RSA
+handshakes are safe in their origin but weak as a standalone live-link exchange,
+and how the Noise handshake supplies the missing properties (offline-attack
+resistance, forward secrecy, MITM resistance, transcript binding).
+
 ## Security Notes
 
-This library is a **proof-of-concept for HiveMind's key bootstrap**. For production use in security-critical applications:
-- Review cryptographic assumptions (PBKDF2 iteration count, RSA key size, OAEP/PSS parameters).
+The **Noise handshake** (`NoiseHandShake`) is the recommended path and provides forward secrecy, PAKE-grade password authentication, replay resistance, and downgrade protection out of the box. The legacy password and RSA handshakes remain for interoperability; when using them in security-critical applications:
+- Prefer a high-entropy shared secret — the password verifier is offline-crackable (see [`docs/security.md`](./docs/security.md)).
 - Ensure channel integrity after handshake (the derived secret should be used with authenticated encryption like AES-GCM or ChaCha20-Poly1305).
 - Validate out-of-band public key distribution (TOFU, PKI, or other models).
-- Consider forward secrecy mechanisms if long-lived keys are at risk.
+- The RSA path has no forward secrecy — a later key compromise decrypts past sessions; use `NoiseHandShake` where that matters.
 
 ## License
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -15,8 +15,16 @@ password path below.
 
 ## Symmetric path — `PasswordHandShake`
 
-A PAKE-style exchange: both parties already share a password and want a
-symmetric key without ever sending the password over the wire.
+Both parties already share a password and derive a symmetric key without ever
+sending the password over the wire. This is Usenet **hSub** (hashed-subject)
+addressing repurposed as a key-confirmation step.
+
+> **It is not a PAKE, despite the shape.** A checkable image of the password
+> (`SHA256(IV ‖ password)`, IV public) travels on the wire, so a passive
+> observer can mount an **offline dictionary attack** against a weak password.
+> Use a high-entropy access key here, and read [`security.md`](security.md)
+> before relying on this path — it is a worked example of why the distinction
+> matters.
 
 1. Each party generates a random 64-bit IV (`generate_iv`).
 2. Each derives a **hsub** (hashed subject) binding the IV to the password
@@ -117,6 +125,11 @@ built from, usable directly for ad-hoc encryption or signing:
 
 This library is the bootstrap primitive, not a full secure-transport stack.
 The derived `secret` must be used with authenticated encryption (AES-GCM,
-ChaCha20-Poly1305), public-key distribution must be validated out of band, and
-the PBKDF2 iteration count, RSA key size, and OAEP/PSS parameters should be
-reviewed before use outside HiveMind.
+ChaCha20-Poly1305), and public-key distribution must be validated out of band.
+
+Both paths have real limits that shape when they are safe to use: the password
+path is offline-guessable and only safe with a high-entropy key, and the RSA
+path provides **no forward secrecy**. These are analysed in depth — with the
+threat model, the exact attacks, and why they are a cautionary tale about
+composing your own crypto — in [`security.md`](security.md). Read it before
+using either handshake outside its original context.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,244 @@
+# Security analysis — what these handshakes protect, and what they don't
+
+This page is the honest threat analysis of the two handshakes in
+`poorman_handshake`. It explains why each construction is *safe for the job it
+was originally built to do*, why neither is *safe enough to be the sole key
+exchange on a live, untrusted link*, and — because that gap is instructive —
+what it teaches about building your own cryptographic protocols.
+
+Read [`protocol.md`](protocol.md) first for how the handshakes actually work.
+Everything below is grounded in the shipped code, not an idealized description.
+
+## Threat model
+
+A handshake here runs over an "insecure channel." Spell out what the adversary
+can do, because the whole analysis turns on it:
+
+- **Passive eavesdropper** — records every byte in both directions. Cannot
+  modify traffic, but keeps the transcript forever and attacks it offline, at
+  their own pace, on their own hardware.
+- **Active attacker** — can also inject, drop, reorder, replay, and modify
+  messages, and can sit between two parties as a machine-in-the-middle (MITM).
+- **Later compromise** — may, at some future point, obtain a node's long-term
+  private key (theft, seizure, a decommissioned disk, cryptanalytic progress).
+
+A key-exchange primitive that is meant to secure real traffic should ideally
+resist all three. The properties that correspond to them have names:
+
+- **Offline-dictionary resistance** — a captured transcript must not let the
+  attacker *test password guesses offline*. Guesses should only be checkable by
+  talking to the honest party, where they can be rate-limited. This is the
+  defining property of a **PAKE** (Password-Authenticated Key Exchange).
+- **Forward secrecy (FS)** — compromising a long-term key later must not
+  decrypt sessions captured earlier.
+- **Authentication / MITM resistance** — each party must be sure it shares the
+  key with the intended peer and no one in the middle.
+- **Transcript / downgrade binding** — the negotiated parameters must be
+  authenticated, so an attacker cannot silently force a weaker mode.
+
+Hold the two handshakes against this list.
+
+## The password path (`PasswordHandShake`)
+
+### What it actually does
+
+From `poorman_handshake/symmetric/`:
+
+1. Each side picks a random 64-bit IV and sends
+   `hsub = hex(IV ‖ SHA256(IV ‖ password))`, truncated to 48 hex chars — i.e.
+   the 64-bit IV followed by **128 bits of the SHA-256** of `IV ‖ password`.
+2. Each side verifies the peer's `hsub` by recomputing it with the peer's IV
+   (stripped from the message) and comparing.
+3. The shared salt is `IV_self XOR IV_peer` — both IVs are on the wire.
+4. The session key is `PBKDF2-HMAC-SHA256(password, salt, 100_000)`.
+
+The password itself is never transmitted.
+
+### Why this is safe — for what it was built for
+
+This is **hSub (hashed-subject)** technology from Usenet nym remailers. There,
+its job is *unlinkable addressing*: a recipient scans `alt.anonymous.messages`,
+recomputes `SHA256(IV ‖ passphrase)` for each Subject line, and recognizes
+"this message is for me" — while an observer cannot link a post to a recipient.
+Message **confidentiality is a completely separate PGP layer** encrypted to the
+nym's key. hSub is the label on the mailbox; PGP is the lock.
+
+In that setting the construction is sound, and for a good reason: it is fine
+that the label is a directly recomputable function of the passphrase, because
+cracking the label only *de-anonymizes a nym* — the body stays PGP-sealed. The
+recipient **must** be able to recompute the hash (that is how they recognize
+their own mail), so being offline-checkable is a feature, not a flaw.
+
+And there is a case where it is genuinely fine here too: if the "password" is a
+**high-entropy random key** (say ≥128 bits), there is simply nothing to
+enumerate, and every attack below evaporates. The construction keeps the
+password secret; the only question is whether the password is *guessable*.
+
+### Why it is not safe enough as a live handshake
+
+The moment this becomes the sole key exchange on a live link — with **no PGP
+layer underneath** and a **human-chosen password** — the very property that
+made it a good address makes it a liability.
+
+1. **It is not a PAKE, though it looks like one.** The wire carries
+   `SHA256(IV ‖ password)` with the IV public: a *checkable image* of the
+   password. A passive eavesdropper who captures one handshake runs an
+   **offline dictionary attack** —
+   ```
+   for guess in wordlist:
+       if SHA256(IV ‖ guess)[:128 bits] == captured_hash:
+           password = guess
+   ```
+   — with no server round-trip, nothing to rate-limit, and nothing to alert on.
+   *"The password never crosses the wire"* is true and irrelevant: you do not
+   need the password on the wire, you need a way to **test guesses**, and the
+   hash is exactly that. Secrecy of the material is not unguessability.
+
+2. **The work factor is trivial.** The oracle is a bare SHA-256, on the order of
+   billions of guesses per second on a commodity GPU. A memorable access key
+   ("attic-pi", "hivemind123") falls in seconds to hours. Note that the
+   `PBKDF2(..., 100_000)` stretching **does not help**: the attacker cracks the
+   fast, unstretched SHA-256 verifier, then runs the recovered password through
+   PBKDF2 themselves. The KDF protects the derived key from precomputation; it
+   does nothing for the password, because a cheaper oracle sits right beside it.
+
+3. **The salt is public.** `salt = IV_a XOR IV_b`, both IVs on the wire, so
+   PBKDF2's salt provides no secrecy — only mild cross-handshake amortization
+   resistance.
+
+4. **No forward secrecy.** The key is a deterministic function of the password
+   alone (the IVs merely salt it and are not secret). Recover the password once
+   and *every* past and future session under it is readable. Nothing ephemeral
+   is ever contributed.
+
+5. **No transcript binding.** Shared knowledge of the password gives a weak form
+   of mutual authentication, but nothing binds the exchange's parameters, and
+   combined with (4) a MITM who later learns the (weak) password owns all of it
+   retroactively.
+
+The contrast with a real PAKE is the whole point: against a PAKE, a captured
+transcript yields **no offline oracle at all**. The only way to test a password
+guess is to run a fresh exchange with the honest server — an *online* guess it
+can throttle and lock. That single property is what makes a weak, memorable
+password safe, and it is precisely what this construction lacks.
+
+## The RSA path (`HandShake` / `HalfHandShake`)
+
+### What it actually does
+
+From `poorman_handshake/asymmetric/`:
+
+1. Each side owns an RSA-2048 keypair and picks a random 32-byte secret.
+2. It encrypts the secret to the peer's public key with **RSA-OAEP**, signs the
+   ciphertext with **RSA-PSS**, and sends `signature ‖ ciphertext`.
+3. `receive_and_verify` checks the PSS signature against the peer's public key,
+   RSA-OAEP-decrypts the peer's secret, and XORs it into its own.
+4. The session key is `secret_a XOR secret_b` (for `HalfHandShake`, only the
+   sender's secret is used).
+
+### Why this is safe — as far as it goes
+
+The paddings are the modern, sound ones: OAEP for encryption and PSS for
+signing, not textbook RSA or PKCS#1 v1.5. Signing the ciphertext gives
+integrity and origin authentication **provided the public key is authentic**.
+XOR-combining two contributions means neither party can unilaterally fix the
+key, so a single misbehaving side cannot force a known key.
+
+### Why it is not safe enough
+
+1. **No forward secrecy — this is the serious one.** The session secret is
+   *RSA key-transported* under a **long-term** key. An attacker who records
+   handshakes today and later obtains a node's RSA private key decrypts the
+   transported secret, and therefore every past session that key established.
+   An ephemeral Diffie-Hellman exchange (e.g. X25519) makes past sessions
+   unrecoverable even given the long-term key; RSA key transport structurally
+   cannot. On its own this disqualifies the RSA path as a modern transport
+   bootstrap.
+
+2. **Authentication is entirely on the caller.** The signature only helps if you
+   already hold the peer's *authentic* public key. First contact with an
+   unauthenticated key is a MITM waiting to happen — the repo's own
+   `examples/simple_mitm.py` and `examples/tofu_mitm.py` demonstrate exactly
+   this. TOFU-pinning or out-of-band pre-distribution is left to the user, and
+   nothing in the handshake binds identities into the transcript.
+
+3. **RSA is heavy and brittle for the target.** 2048-bit RSA is large and slow
+   on the ESP32 / MicroPython class of nodes this ecosystem targets, and any
+   future slip in decrypt-error handling reintroduces padding-oracle risk that
+   an ECDH exchange never has.
+
+4. **`HalfHandShake` is weaker still** — only the sender contributes, so the
+   sender fully determines the key; there is no mutual randomness.
+
+## The cautionary tale: why this is a case study in *not* rolling your own crypto
+
+None of the individual pieces here are broken. SHA-256, PBKDF2, RSA-OAEP,
+RSA-PSS, hSub addressing — all are fine, well-understood primitives used within
+their specs. **The vulnerability lives entirely in the composition**, and that
+is almost always where do-it-yourself cryptography fails. A few lessons fall
+straight out of the analysis above:
+
+- **"It never sends the secret" is not a security argument.** The most seductive
+  wrong intuition in applied crypto is: *if the secret material never crosses
+  the wire, it must be protected.* But a *verifiable image* of the secret
+  crossing the wire is enough to break it, because the attacker's job is to
+  **test guesses**, not to read the secret. Confidentiality of the bytes and
+  unguessability of the secret are different properties; this construction has
+  the first and lacks the second.
+
+- **The name was the tell.** `protocol.md` used to call the password path
+  "PAKE-style." It has the *silhouette* of a PAKE — shared password in, shared
+  key out, password never transmitted — without the one property that *defines*
+  a PAKE: no offline dictionary attack. Building something that resembles a
+  known primitive is not the same as building the primitive, and "-style" or
+  "-inspired" in a crypto description is a reliable warning sign that a security
+  property was approximated by shape rather than achieved.
+
+- **It passes every test except the adversary.** Both sides derive the same
+  key; the unit tests are green; the demo works. Correctness tests confirm that
+  *honest* parties agree — they say nothing about what a *dishonest* party can
+  do. Cryptographic security is a property against an adversary you have to
+  explicitly model, and a hand-built protocol ships with neither a threat model
+  nor a proof, so the gap only surfaces under an attacker you did not think of
+  (here: offline guessing, and future key compromise).
+
+- **Reusing good tech in the wrong context is still a bug.** hSub is *correct*
+  remailer technology, and HiveMind's Usenet transport still uses it correctly —
+  as an unlinkable label with a separate PGP layer doing confidentiality. The
+  error was carrying that same construction onto a live link where nothing sits
+  underneath it, so a mechanism designed to *address* mail was asked to
+  *establish a session key*. Context is part of a primitive's contract.
+
+- **"Use vetted crypto" means vetted *protocols*, not just vetted ciphers.** The
+  fix is not "use a library's AES instead of writing AES." It is: **use a
+  reviewed key-exchange protocol** — Noise, TLS 1.3, or a real asymmetric PAKE
+  such as OPAQUE or SPAKE2 — instead of assembling your own handshake out of
+  hashes and RSA calls. A protocol comes with a threat model and a proof; a
+  hand-wired handshake comes with neither, and this page is what the difference
+  looks like.
+
+## What replaces it, and what to do meanwhile
+
+HiveMind protocol **v3** moves the shared password into the **PSK slot of
+`Noise_XXpsk2`** (X25519 + ChaCha20-Poly1305 + SHA-256), with `Noise_KKpsk0`
+for the pre-provisioned-keys case. That single, reviewed pattern supplies the
+four properties this bespoke handshake lacked, all at once:
+
+- the wire messages stop being a checkable image of the password → **offline-
+  dictionary resistance** (the real PAKE property);
+- an ephemeral X25519 exchange → **forward secrecy**;
+- mutual static-key authentication → **MITM resistance**;
+- the negotiated parameters mixed into the handshake hash → **transcript /
+  downgrade binding**.
+
+Until you are on v3, if you must use this library:
+
+- **Use a high-entropy random access key (≥128 bits), never a human
+  passphrase.** This is the one change that actually neutralizes the password
+  path's offline-dictionary weakness — there is nothing to enumerate.
+- Treat the RSA path as providing **no forward secrecy**, and **validate public
+  keys out of band** (TOFU-pin or pre-distribute); never accept an unauthenticated
+  key on first contact in a hostile setting.
+- Always wrap the derived `secret` in authenticated encryption (AES-GCM,
+  ChaCha20-Poly1305) — the handshake is a bootstrap, not a transport.
+- Prefer the v3 Noise handshake wherever it is available.

--- a/examples/noise_handshake.py
+++ b/examples/noise_handshake.py
@@ -1,0 +1,62 @@
+from poorman_handshake.noise import NoiseHandShake
+
+"""
+Noise handshake (HiveMind protocol v3) — the recommended path.
+
+Both peers share a site *password*. Unlike the password (hSub) handshake,
+the password here enters as the Noise PSK: the on-wire messages are NOT an
+offline-crackable image of it, and the session keys come from an ephemeral
+X25519 exchange, so:
+
+  - a passive observer cannot mount an offline dictionary attack (PAKE-grade);
+  - past sessions stay secret even if the password later leaks (forward secrecy);
+  - a machine-in-the-middle without the password cannot complete the handshake.
+
+This example uses the default XXpsk2 pattern: neither side needs the other's
+static key in advance; each *learns and can pin* it during the exchange (TOFU).
+"""
+
+# The shared secret, plus the server's node id (used as the PSK salt so two
+# different servers derive different keys from the same password).
+PASSWORD = "correct horse battery staple"
+NODE_ID = "server-01"
+
+# alice = the connecting node (initiator); bob = the server (responder).
+alice = NoiseHandShake(initiator=True, password=PASSWORD, node_id=NODE_ID)
+bob = NoiseHandShake(initiator=False, password=PASSWORD, node_id=NODE_ID)
+
+
+#### Insecure communication starts here — these three messages may cross any
+#### untrusted channel (no TLS required).
+
+# XXpsk2 is a three-message pattern:
+msg1 = alice.write_message()   # -> e
+bob.read_message(msg1)
+
+msg2 = bob.write_message()     # -> e, ee, s, es, psk
+alice.read_message(msg2)
+
+msg3 = alice.write_message()   # -> s, se
+bob.read_message(msg3)
+
+assert alice.handshake_finished and bob.handshake_finished
+print("Handshake complete — both sides derived matching transport keys.")
+
+# Trust-on-first-use: each side now holds the other's static public key and
+# SHOULD pin it, so a later handshake with a different key is rejected.
+assert alice.remote_pubkey == bob.pubkey_bytes
+assert bob.remote_pubkey == alice.pubkey_bytes
+print("Static keys learned and ready to pin (TOFU).")
+
+# The handshake hash is a shared transcript fingerprint (channel binding).
+assert alice.handshake_hash == bob.handshake_hash
+
+#### Encrypted session starts here
+
+# Transport messages carry per-CipherState counter nonces, so a replayed or
+# reordered frame fails to decrypt — replay resistance for free.
+ciphertext = alice.encrypt(b"hello over the mesh")
+print("bob decrypts:", bob.decrypt(ciphertext))
+
+reply = bob.encrypt(b"ack")
+print("alice decrypts:", alice.decrypt(reply))

--- a/examples/noise_kk.py
+++ b/examples/noise_kk.py
@@ -1,0 +1,50 @@
+from poorman_handshake.noise import NoiseHandShake
+
+"""
+Noise KKpsk0 handshake — the pre-provisioned variant.
+
+Use this when both peers already hold each other's static public keys (for
+example, keys pinned from a previous XXpsk2 handshake, or distributed out of
+band). KK authenticates both static keys from the very first message and is a
+two-message pattern.
+
+As in the XX example, the shared password enters as the PSK, so authentication
+does not depend on transport security.
+"""
+
+PASSWORD = "correct horse battery staple"
+NODE_ID = "server-01"
+
+# Persist each side's static X25519 key so it survives restarts (and so pins
+# established elsewhere keep matching).
+alice_key = "alice_noise.key"
+bob_key = "bob_noise.key"
+
+# First, learn each other's static public keys (any prior channel / pinning).
+alice_pub = NoiseHandShake(initiator=True, password=PASSWORD, node_id=NODE_ID,
+                           path=alice_key).pubkey
+bob_pub = NoiseHandShake(initiator=False, password=PASSWORD, node_id=NODE_ID,
+                         path=bob_key).pubkey
+
+# Now run KKpsk0 with the remote static key supplied up front (this selects the
+# KK pattern automatically).
+alice = NoiseHandShake(initiator=True, password=PASSWORD, node_id=NODE_ID,
+                       path=alice_key, remote_pubkey=bob_pub)
+bob = NoiseHandShake(initiator=False, password=PASSWORD, node_id=NODE_ID,
+                     path=bob_key, remote_pubkey=alice_pub)
+
+#### Insecure communication starts here
+
+msg1 = alice.write_message()   # -> psk, e, es, ss
+bob.read_message(msg1)
+
+msg2 = bob.write_message()     # -> e, ee, se
+alice.read_message(msg2)
+
+assert alice.handshake_finished and bob.handshake_finished
+print("KK handshake complete — mutual static-key authentication from message one.")
+
+#### Encrypted session starts here
+
+ciphertext = alice.encrypt(b"hello again")
+print("bob decrypts:", bob.decrypt(ciphertext))

--- a/poorman_handshake/asymmetric/__init__.py
+++ b/poorman_handshake/asymmetric/__init__.py
@@ -4,6 +4,7 @@ from os.path import isfile
 from typing import Union, Optional
 
 import logging
+import warnings
 import shutil
 from Cryptodome.PublicKey import RSA
 from Cryptodome.Random import get_random_bytes
@@ -18,11 +19,13 @@ from poorman_handshake.asymmetric.utils import (
     sign_RSA,
     verify_RSA,
 )
-
-
 class HandShake:
     """
-    Class for performing a secure handshake using RSA encryption and signatures.
+    RSA handshake using encryption and signatures (legacy; **discouraged**).
+
+    .. deprecated::
+        No forward secrecy and MITM-vulnerable on first contact. Prefer
+        :class:`poorman_handshake.noise.NoiseHandShake`.
 
     Attributes:
         private_key (RSA.RsaKey): The private RSA key for this handshake instance.
@@ -38,6 +41,15 @@ class HandShake:
             path (str, optional): Path to load or save the private key.
             key_size (int, optional): Size of the RSA key in bits (default is 2048).
         """
+        warnings.warn(
+            "RSA handshakes (HandShake/HalfHandShake) have no forward secrecy — a "
+            "later private-key compromise decrypts every past session — and are "
+            "vulnerable to a machine-in-the-middle on first contact. They are kept "
+            "for legacy interoperability; for new code use "
+            "poorman_handshake.noise.NoiseHandShake (see docs/security.md).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.private_key = None
         if path and isfile(path):
 
@@ -170,7 +182,11 @@ class HandShake:
 
 class HalfHandShake(HandShake):
     """
-    A simpler handshake implementation where the shared secret is directly decrypted.
+    One-way RSA handshake, secret chosen by the sender (legacy; **discouraged**).
+
+    Prefer :class:`poorman_handshake.noise.NoiseHandShake` — see docs/security.md.
+    Instantiation emits the RSA-handshake warning inherited from
+    :class:`HandShake`.
     """
 
     def receive_handshake(self, shake: Union[str, bytes]):

--- a/poorman_handshake/symmetric/__init__.py
+++ b/poorman_handshake/symmetric/__init__.py
@@ -1,9 +1,27 @@
 from poorman_handshake.symmetric.utils import *
 import hashlib
+import warnings
 
 
 class PasswordHandShake:
+    """Password-based key agreement (legacy; **discouraged**).
+
+    Not a PAKE — the on-wire verifier is an offline-crackable image of the
+    password. Prefer :class:`poorman_handshake.noise.NoiseHandShake`
+    (see docs/security.md).
+    """
+
     def __init__(self, password):
+        warnings.warn(
+            "PasswordHandShake is not a PAKE: it sends a salted-hash verifier of "
+            "the password that a passive observer can attack offline, and it has "
+            "no forward secrecy. It is kept for HiveMind protocol v0-v2 "
+            "interoperability; for new code use "
+            "poorman_handshake.noise.NoiseHandShake, or only use this with a "
+            "high-entropy shared secret (see docs/security.md).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.password = password
         self.iv = None
         self.salt = None


### PR DESCRIPTION
Adds `docs/security.md` — a threat-model-grounded analysis of the password (hSub) and RSA handshake constructions: why they are sound in their origin (remailer addressing, with a separate PGP layer) but fail as a live-link key exchange — the hSub verifier is an offline-crackable image of a low-entropy password, no forward secrecy, no MITM resistance — and how protocol v3's Noise_XXpsk2 supplies the missing properties (PAKE-grade password auth, ephemeral X25519 forward secrecy, transcript binding). Corrects the "PAKE-style" mischaracterization in `docs/protocol.md`. Companion to CRYPTO-1 v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)