### PR TITLE
Keep long machine secrets within zxcvbn limits

### DIFF
--- a/poorman_handshake/symmetric/strength.py
+++ b/poorman_handshake/symmetric/strength.py
@@ -15,6 +15,7 @@ from zxcvbn import zxcvbn
 
 # zxcvbn reports guesses as a base-10 magnitude; convert to bits of resistance.
 _BITS_PER_LOG10 = log2(10)
+_ZXCVBN_MAX_LENGTH = 72
 
 #: Default minimum guess resistance (in bits) required of a password. Chosen so
 #: obviously guessable secrets ("Password123!", "correct_password", the xkcd
@@ -26,6 +27,21 @@ class WeakPasswordError(ValueError):
     """Raised when a password is too weak/guessable for the password handshake."""
 
 
+def _normalize_password(password: Union[str, bytes]) -> str:
+    return password.decode("utf-8", "replace") if isinstance(password, bytes) else password
+
+
+def _estimate_password(password: Union[str, bytes]) -> dict:
+    """Run zxcvbn within its input limit.
+
+    zxcvbn rejects inputs longer than 72 characters. HiveMind deployments often
+    use longer machine-generated shared secrets, so score the leading 72
+    characters instead of failing before the strength check can run.
+    """
+    pw = _normalize_password(password)
+    return zxcvbn(pw[:_ZXCVBN_MAX_LENGTH])
+
+
 def password_bits(password: Union[str, bytes]) -> float:
     """Return the estimated guess resistance of ``password`` in bits.
 
@@ -33,9 +49,7 @@ def password_bits(password: Union[str, bytes]) -> float:
     that accounts for dictionary words, keyboard patterns, and substitutions,
     unlike a naive character-set entropy estimate.
     """
-    if isinstance(password, bytes):
-        password = password.decode("utf-8", "replace")
-    return zxcvbn(password)["guesses_log10"] * _BITS_PER_LOG10
+    return _estimate_password(password)["guesses_log10"] * _BITS_PER_LOG10
 
 
 def check_password_strength(
@@ -50,8 +64,7 @@ def check_password_strength(
         return
     if not password:
         raise WeakPasswordError("password must be a non-empty string")
-    pw = password.decode("utf-8", "replace") if isinstance(password, bytes) else password
-    result = zxcvbn(pw)
+    result = _estimate_password(password)
     bits = result["guesses_log10"] * _BITS_PER_LOG10
     if bits < min_bits:
         feedback = result.get("feedback") or {}

--- a/tests/test_password_strength.py
+++ b/tests/test_password_strength.py
@@ -22,6 +22,11 @@ STRONG = [
     "MyDogChews5Bones every Tuesday",
 ]
 
+LONG_MACHINE_SECRET = (
+    "N7hPp0kCq9Zr2sVx6bLd4mTa8WfY3jQe5uIg1oSnKcR94HzXvBt6PaDy"
+    "M2lEwUqF8gJs0nRb5Tz"
+)
+
 
 @pytest.mark.parametrize("pw", WEAK)
 def test_weak_passwords_are_refused(pw):
@@ -56,6 +61,16 @@ def test_empty_password_refused():
 def test_bytes_password_supported():
     with pytest.raises(WeakPasswordError):
         check_password_strength(b"password")
+
+
+def test_long_machine_generated_password_supported():
+    PasswordHandShake(LONG_MACHINE_SECRET)
+    assert password_bits(LONG_MACHINE_SECRET) >= 40
+
+
+def test_long_guessable_password_still_refused():
+    with pytest.raises(WeakPasswordError):
+        PasswordHandShake("password" * 12)
 
 
 def test_password_bits_orders_by_strength():


### PR DESCRIPTION
Fixes #23

## Issue
Runtime setup secrets can be longer than zxcvbn accepts, so strength checking can throw before it can decide pass/fail.

## Improves
- Scores the first zxcvbn-supported slice for long machine secrets.
- Still rejects long guessable strings instead of blindly accepting them.
- Keeps normal password-strength behavior unchanged.

## Tested
- `python -m pytest tests/test_password_strength.py tests/test_password_handshake.py`