### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Poor Man's Handshake
 
-Securely exchange symmetric encryption keys over insecure channels using a Noise-framework handshake or the legacy password / RSA handshakes. This library provides the cryptographic bootstrap primitive for the HiveMind distributed mesh — nodes use it to establish a shared session secret before raising an encrypted channel.
+Securely exchange symmetric encryption keys over insecure channels using a Noise-framework handshake or the legacy password / RSA handshakes. This library provides the cryptographic bootstrap primitive for the HiveMind distributed mesh. Nodes use it to establish a shared session secret before raising an encrypted channel.
 
-> **Which handshake should I use?** The **Noise handshake** (`NoiseHandShake`) is the recommended path: it adds forward secrecy, PAKE-grade password authentication (no offline-crackable image on the wire), replay resistance, and downgrade protection that the password and RSA handshakes lack. The legacy handshakes remain for interoperability with existing deployments. See [`docs/security.md`](docs/security.md) for the full analysis of why.
+> **Which handshake should I use?** The **Noise handshake** (`NoiseHandShake`) is the recommended path. It adds forward secrecy, PAKE-grade password authentication (no offline-crackable image on the wire), replay resistance, and downgrade protection. The password and RSA handshakes lack these properties. The legacy handshakes remain for interoperability with existing deployments. See [`docs/security.md`](docs/security.md) for the full analysis.
 
 ## Features
 
-- **Noise handshake** (`NoiseHandShake`): A [Noise Protocol Framework](https://noiseprotocol.org/) authenticated key exchange (`Noise_XXpsk2` / `Noise_KKpsk0` over X25519 + ChaCha20-Poly1305 + SHA-256). The shared password enters as the Noise PSK — never as an on-wire image — and session keys come from an ephemeral X25519 exchange, giving **forward secrecy**, **PAKE-grade** password authentication, per-message **replay resistance**, and prologue-bound **downgrade protection**. Static keys are learned during `XX` for trust-on-first-use pinning. This is HiveMind protocol v3.
-- **Password-based key exchange** (`PasswordHandShake`): Derive a shared symmetric key from a pre-shared password without ever transmitting the password. Each party generates a random IV, hashes it with the password, and XORs the IVs to form a common salt. The final key is derived via PBKDF2-HMAC-SHA256. Note: the on-wire verifier is an offline-crackable image of the password (safe only with a high-entropy secret) — prefer `NoiseHandShake`.
+- **Noise handshake** (`NoiseHandShake`): A [Noise Protocol Framework](https://noiseprotocol.org/) authenticated key exchange (`Noise_XXpsk2` / `Noise_KKpsk0` over X25519 + ChaCha20-Poly1305 + SHA-256). The shared password enters as the Noise PSK, never as an on-wire image. Session keys come from an ephemeral X25519 exchange, giving **forward secrecy**, **PAKE-grade** password authentication, per-message **replay resistance**, and prologue-bound **downgrade protection**. Static keys are learned during `XX` for trust-on-first-use pinning. This is HiveMind protocol v3.
+- **Password-based key exchange** (`PasswordHandShake`): Derive a shared symmetric key from a pre-shared password without ever transmitting the password. Each party generates a random IV, hashes it with the password, and XORs the IVs to form a common salt. The final key is derived via PBKDF2-HMAC-SHA256. The on-wire verifier is an offline-crackable image of the password, safe only with a high-entropy secret. Prefer `NoiseHandShake` instead.
 - **RSA public-key exchange** (`HandShake`): Mutual RSA key agreement where both parties contribute a random secret. The secrets are XORed to form the final shared key, ensuring both contributions are needed.
 - **Asymmetric exchange** (`HalfHandShake`): One-way key agreement for asymmetric trust scenarios (only one party's secret is used).
 - **Hybrid RSA+AES-GCM encryption**: Arbitrary-length plaintext support via RSA-encrypted AES keys.
@@ -25,8 +25,8 @@ Requires Python 3.10+, `pycryptodomex >= 3.19.1`, `noiseprotocol >= 0.3.1`, `arg
 
 ### Noise handshake (recommended)
 
-Both peers share a site *password*; the connecting node initiates. The default
-`XXpsk2` pattern needs no prior knowledge of the peer's static key — each side
+Both peers share a site *password*. The connecting node starts the exchange. The default
+`XXpsk2` pattern needs no prior knowledge of the peer's static key. Each side
 learns and can pin it during the exchange.
 
 ```python
@@ -110,7 +110,7 @@ print(f"Shared secret: {alice.secret.hex()}")
 
 ### One-way handshake (asymmetric trust)
 
-`HalfHandShake` derives the secret directly without XOR, for scenarios where only one party's contribution matters. The sender chooses the secret and encrypts it with the receiver's public key; the receiver authenticates the sender and decrypts the secret. Only the receiver needs the sender's public key in advance:
+`HalfHandShake` derives the secret directly without XOR, for scenarios where only one party's contribution matters. The sender chooses the secret and encrypts it with the receiver's public key. The receiver authenticates the sender and decrypts the secret. Only the receiver needs the sender's public key in advance:
 
 ```python
 from poorman_handshake import HalfHandShake
@@ -155,8 +155,8 @@ NoiseHandShake(
 - `path`: Optional file to load/persist the static X25519 key (generated if absent).
 - `password` / `node_id`: Shared password, stretched into the 32-byte PSK with argon2id salted by `SHA-256(node_id)`. Provide either this pair or `psk`.
 - `psk`: A pre-derived 32-byte pre-shared key (alternative to `password`).
-- `remote_pubkey`: Peer static public key (hex or 32 raw bytes). Supplying it selects `KKpsk0`; omitting it uses `XXpsk2` (learn-and-pin).
-- `prologue`: Bytes bound into the handshake hash for downgrade protection; both sides must supply identical bytes. Encode the negotiated protocol version and cipher/encoding lists here.
+- `remote_pubkey`: Peer static public key (hex or 32 raw bytes). Supplying it selects `KKpsk0`. Omitting it uses `XXpsk2` (learn-and-pin).
+- `prologue`: Bytes bound into the handshake hash for downgrade protection. Both sides must supply identical bytes. Encode the negotiated protocol version and cipher/encoding lists here.
 - `pattern`: Override the Noise protocol name (defaults per `remote_pubkey`).
 
 **Methods:**
@@ -169,7 +169,7 @@ NoiseHandShake(
 **Properties:**
 - `handshake_finished: bool`: Whether the handshake is complete.
 - `pubkey: str` / `pubkey_bytes: bytes`: This node's static public key.
-- `remote_pubkey: bytes | None`: The peer's static public key (learned during `XX`); pin it for TOFU.
+- `remote_pubkey: bytes | None`: The peer's static public key, learned during `XX`. Pin it for TOFU.
 - `handshake_hash: bytes | None`: Shared transcript fingerprint for channel binding.
 
 ### `derive_psk(password, node_id=None, salt=None) -> bytes`
@@ -178,7 +178,7 @@ Derive a 32-byte Noise PSK from a password using argon2id. The salt defaults to 
 
 ### `PasswordHandShake`
 
-Password-based key agreement. **Not a PAKE** — the handshake transmits a salted-hash *verifier* of the password, which a passive observer can attack offline; it is safe only with a high-entropy shared secret. For a low-entropy password, use `NoiseHandShake` instead (see [`docs/security.md`](docs/security.md)).
+Password-based key agreement. **Not a PAKE.** The handshake transmits a salted-hash *verifier* of the password, which a passive observer can attack offline. It is safe only with a high-entropy shared secret. For a low-entropy password, use `NoiseHandShake` instead (see [`docs/security.md`](docs/security.md)).
 
 **Constructor:**
 ```python
@@ -187,7 +187,7 @@ PasswordHandShake(password: str, min_bits: float = 40)
 - `password`: Pre-shared password string.
 - `min_bits`: Minimum estimated guess resistance (bits, via zxcvbn). The constructor raises `WeakPasswordError` for a weaker password. Pass `min_bits=0` to disable the check (e.g. for a machine-generated high-entropy secret).
 
-> ⚠️ **Breaking:** since the on-wire verifier is offline-crackable, weak passwords are now **refused** by default. Use a strong passphrase, `min_bits=0` to opt out, or prefer `NoiseHandShake`.
+> **Breaking:** the on-wire verifier is offline-crackable, so weak passwords are now **refused** by default. Use a strong passphrase, pass `min_bits=0` to opt out, or prefer `NoiseHandShake`.
 
 **Methods:**
 - `generate_handshake() -> str`: Generate a hex-encoded handshake message (hsub).
@@ -274,12 +274,12 @@ resistance, forward secrecy, MITM resistance, transcript binding).
 
 ## Security Notes
 
-The **Noise handshake** (`NoiseHandShake`) is the recommended path and provides forward secrecy, PAKE-grade password authentication, replay resistance, and downgrade protection out of the box. The legacy password and RSA handshakes remain for interoperability; when using them in security-critical applications:
-- Prefer a high-entropy shared secret — the password verifier is offline-crackable (see [`docs/security.md`](./docs/security.md)).
+The **Noise handshake** (`NoiseHandShake`) is the recommended path and provides forward secrecy, PAKE-grade password authentication, replay resistance, and downgrade protection out of the box. The legacy password and RSA handshakes remain for interoperability. When using them in security-critical applications:
+- Prefer a high-entropy shared secret. The password verifier is offline-crackable (see [`docs/security.md`](./docs/security.md)).
 - Ensure channel integrity after handshake (the derived secret should be used with authenticated encryption like AES-GCM or ChaCha20-Poly1305).
 - Validate out-of-band public key distribution (TOFU, PKI, or other models).
-- The RSA path has no forward secrecy — a later key compromise decrypts past sessions; use `NoiseHandShake` where that matters.
+- The RSA path has no forward secrecy. A later key compromise decrypts past sessions, so use `NoiseHandShake` where that matters.
 
 ## License
 
-Apache License 2.0 — see [LICENSE.md](./LICENSE.md).
+Apache License 2.0. See [LICENSE.md](./LICENSE.md).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -13,7 +13,7 @@ authenticated symmetric encryption. The access key handed out by
 `hivemind-core add-client` is the pre-shared password consumed by the
 password path below.
 
-## Symmetric path — `PasswordHandShake`
+## Symmetric path: `PasswordHandShake`
 
 Both parties already share a password and derive a symmetric key without ever
 sending the password over the wire. This is Usenet **hSub** (hashed-subject)
@@ -23,7 +23,7 @@ addressing repurposed as a key-confirmation step.
 > (`SHA256(IV ‖ password)`, IV public) travels on the wire, so a passive
 > observer can mount an **offline dictionary attack** against a weak password.
 > Use a high-entropy access key here, and read [`security.md`](security.md)
-> before relying on this path — it is a worked example of why the distinction
+> before relying on this path. It is a worked example of why the distinction
 > matters.
 
 1. Each party generates a random 64-bit IV (`generate_iv`).
@@ -31,7 +31,7 @@ addressing repurposed as a key-confirmation step.
    (`create_hsub`) and sends it as the handshake message.
 3. On receipt, each party extracts the peer's IV (`iv_from_hsub`) and verifies
    the hsub against the shared password (`match_hsub`). A mismatch means the
-   peer does not hold the password — the handshake is rejected.
+   peer does not hold the password, so the handshake is rejected.
 4. The two IVs are XORed into a common salt, and the final key is derived with
    PBKDF2-HMAC-SHA256 over the password and that salt.
 
@@ -49,7 +49,7 @@ assert a.receive_and_verify(hb) and b.receive_and_verify(ha)
 assert compare_digest(a.secret, b.secret)
 ```
 
-## Asymmetric path — `HandShake`
+## Asymmetric path: `HandShake`
 
 Mutual RSA key agreement where **both** parties contribute randomness, so a
 single compromised party cannot dictate the key.
@@ -76,7 +76,7 @@ a.receive_and_verify(hb); b.receive_and_verify(ha)
 assert compare_digest(a.secret, b.secret)
 ```
 
-### One-way — `HalfHandShake`
+### One-way: `HalfHandShake`
 
 Subclass of `HandShake` for asymmetric trust: the **sender** chooses the secret
 and the **receiver** authenticates the sender. Only the sender's contribution
@@ -100,9 +100,9 @@ assert compare_digest(receiver.secret, sender.secret)
 stable public identity across restarts. With stable keys you can layer a trust
 model on top of the raw exchange:
 
-- **TOFU (trust on first use)** — pin a peer's public key the first time it is
-  seen and reject changes thereafter. See `examples/tofu_handshake.py`.
-- **Pre-distributed keys** — ship known public keys out of band and refuse
+- **TOFU (trust on first use)**: pin a peer's public key the first time it is
+  seen and reject changes after that. See `examples/tofu_handshake.py`.
+- **Pre-distributed keys**: ship known public keys out of band and refuse
   unknown peers. See `examples/static_handshake.py`.
 
 The `examples/*_mitm.py` scripts demonstrate why out-of-band public-key
@@ -115,11 +115,11 @@ side already knows the other's authentic public key.
 `poorman_handshake.asymmetric.utils` exposes the primitives the handshake is
 built from, usable directly for ad-hoc encryption or signing:
 
-- `encrypt_RSA` / `decrypt_RSA` — RSA-OAEP for short payloads.
-- `hybrid_encrypt_RSA` / `hybrid_decrypt_RSA` — RSA-wrapped AES-GCM for
+- `encrypt_RSA` / `decrypt_RSA`: RSA-OAEP for short payloads.
+- `hybrid_encrypt_RSA` / `hybrid_decrypt_RSA`: RSA-wrapped AES-GCM for
   arbitrary-length payloads.
-- `sign_RSA` / `verify_RSA` — RSA-PSS signatures.
-- `load_RSA_key` / `export_RSA_key` / `create_RSA_key` — PEM key management.
+- `sign_RSA` / `verify_RSA`: RSA-PSS signatures.
+- `load_RSA_key` / `export_RSA_key` / `create_RSA_key`: PEM key management.
 
 ## Security caveats
 
@@ -129,7 +129,10 @@ ChaCha20-Poly1305), and public-key distribution must be validated out of band.
 
 Both paths have real limits that shape when they are safe to use: the password
 path is offline-guessable and only safe with a high-entropy key, and the RSA
-path provides **no forward secrecy**. These are analysed in depth — with the
+path provides **no forward secrecy**. These are analyzed in depth, with the
 threat model, the exact attacks, and why they are a cautionary tale about
-composing your own crypto — in [`security.md`](security.md). Read it before
+composing your own crypto, in [`security.md`](security.md). Read it before
 using either handshake outside its original context.
+
+---
+[Home](../README.md) · [Security analysis →](security.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,9 +1,9 @@
-# Security analysis — what these handshakes protect, and what they don't
+# Security analysis: what these handshakes protect, and what they don't
 
 This page is the honest threat analysis of the two handshakes in
 `poorman_handshake`. It explains why each construction is *safe for the job it
 was originally built to do*, why neither is *safe enough to be the sole key
-exchange on a live, untrusted link*, and — because that gap is instructive —
+exchange on a live, untrusted link*. Because that gap is instructive, this page also covers
 what it teaches about building your own cryptographic protocols.
 
 Read [`protocol.md`](protocol.md) first for how the handshakes actually work.
@@ -14,26 +14,26 @@ Everything below is grounded in the shipped code, not an idealized description.
 A handshake here runs over an "insecure channel." Spell out what the adversary
 can do, because the whole analysis turns on it:
 
-- **Passive eavesdropper** — records every byte in both directions. Cannot
+- **Passive eavesdropper**: records every byte in both directions. Cannot
   modify traffic, but keeps the transcript forever and attacks it offline, at
   their own pace, on their own hardware.
-- **Active attacker** — can also inject, drop, reorder, replay, and modify
+- **Active attacker**: can also inject, drop, reorder, replay, and modify
   messages, and can sit between two parties as a machine-in-the-middle (MITM).
-- **Later compromise** — may, at some future point, obtain a node's long-term
+- **Later compromise**: may, at some future point, obtain a node's long-term
   private key (theft, seizure, a decommissioned disk, cryptanalytic progress).
 
 A key-exchange primitive that is meant to secure real traffic should ideally
 resist all three. The properties that correspond to them have names:
 
-- **Offline-dictionary resistance** — a captured transcript must not let the
+- **Offline-dictionary resistance**: a captured transcript must not let the
   attacker *test password guesses offline*. Guesses should only be checkable by
   talking to the honest party, where they can be rate-limited. This is the
   defining property of a **PAKE** (Password-Authenticated Key Exchange).
-- **Forward secrecy (FS)** — compromising a long-term key later must not
+- **Forward secrecy (FS)**: compromising a long-term key later must not
   decrypt sessions captured earlier.
-- **Authentication / MITM resistance** — each party must be sure it shares the
+- **Authentication / MITM resistance**: each party must be sure it shares the
   key with the intended peer and no one in the middle.
-- **Transcript / downgrade binding** — the negotiated parameters must be
+- **Transcript / downgrade binding**: the negotiated parameters must be
   authenticated, so an attacker cannot silently force a weaker mode.
 
 Hold the two handshakes against this list.
@@ -45,51 +45,51 @@ Hold the two handshakes against this list.
 From `poorman_handshake/symmetric/`:
 
 1. Each side picks a random 64-bit IV and sends
-   `hsub = hex(IV ‖ SHA256(IV ‖ password))`, truncated to 48 hex chars — i.e.
+   `hsub = hex(IV ‖ SHA256(IV ‖ password))`, truncated to 48 hex chars. That is,
    the 64-bit IV followed by **128 bits of the SHA-256** of `IV ‖ password`.
 2. Each side verifies the peer's `hsub` by recomputing it with the peer's IV
    (stripped from the message) and comparing.
-3. The shared salt is `IV_self XOR IV_peer` — both IVs are on the wire.
+3. The shared salt is `IV_self XOR IV_peer`. Both IVs are on the wire.
 4. The session key is `PBKDF2-HMAC-SHA256(password, salt, 100_000)`.
 
 The password itself is never transmitted.
 
-### Why this is safe — for what it was built for
+### Why this is safe: for what it was built for
 
 This is **hSub (hashed-subject)** technology from Usenet nym remailers. There,
 its job is *unlinkable addressing*: a recipient scans `alt.anonymous.messages`,
 recomputes `SHA256(IV ‖ passphrase)` for each Subject line, and recognizes
-"this message is for me" — while an observer cannot link a post to a recipient.
+"this message is for me," while an observer cannot link a post to a recipient.
 Message **confidentiality is a completely separate PGP layer** encrypted to the
-nym's key. hSub is the label on the mailbox; PGP is the lock.
+nym's key. hSub is the label on the mailbox. PGP is the lock.
 
 In that setting the construction is sound, and for a good reason: it is fine
 that the label is a directly recomputable function of the passphrase, because
-cracking the label only *de-anonymizes a nym* — the body stays PGP-sealed. The
+cracking the label only *de-anonymizes a nym*. The body stays PGP-sealed. The
 recipient **must** be able to recompute the hash (that is how they recognize
 their own mail), so being offline-checkable is a feature, not a flaw.
 
 And there is a case where it is genuinely fine here too: if the "password" is a
 **high-entropy random key** (say ≥128 bits), there is simply nothing to
 enumerate, and every attack below evaporates. The construction keeps the
-password secret; the only question is whether the password is *guessable*.
+password secret. The only question is whether the password is *guessable*.
 
 ### Why it is not safe enough as a live handshake
 
-The moment this becomes the sole key exchange on a live link — with **no PGP
-layer underneath** and a **human-chosen password** — the very property that
+The moment this becomes the sole key exchange on a live link, with **no PGP
+layer underneath** and a **human-chosen password**, the very property that
 made it a good address makes it a liability.
 
 1. **It is not a PAKE, though it looks like one.** The wire carries
    `SHA256(IV ‖ password)` with the IV public: a *checkable image* of the
    password. A passive eavesdropper who captures one handshake runs an
-   **offline dictionary attack** —
+   **offline dictionary attack**:
    ```
    for guess in wordlist:
        if SHA256(IV ‖ guess)[:128 bits] == captured_hash:
            password = guess
    ```
-   — with no server round-trip, nothing to rate-limit, and nothing to alert on.
+   This runs with no server round-trip, nothing to rate-limit, and nothing to alert on.
    *"The password never crosses the wire"* is true and irrelevant: you do not
    need the password on the wire, you need a way to **test guesses**, and the
    hash is exactly that. Secrecy of the material is not unguessability.
@@ -99,11 +99,11 @@ made it a good address makes it a liability.
    ("attic-pi", "hivemind123") falls in seconds to hours. Note that the
    `PBKDF2(..., 100_000)` stretching **does not help**: the attacker cracks the
    fast, unstretched SHA-256 verifier, then runs the recovered password through
-   PBKDF2 themselves. The KDF protects the derived key from precomputation; it
+   PBKDF2 themselves. The KDF protects the derived key from precomputation. It
    does nothing for the password, because a cheaper oracle sits right beside it.
 
 3. **The salt is public.** `salt = IV_a XOR IV_b`, both IVs on the wire, so
-   PBKDF2's salt provides no secrecy — only mild cross-handshake amortization
+   PBKDF2's salt provides no secrecy, only mild cross-handshake amortization
    resistance.
 
 4. **No forward secrecy.** The key is a deterministic function of the password
@@ -118,7 +118,7 @@ made it a good address makes it a liability.
 
 The contrast with a real PAKE is the whole point: against a PAKE, a captured
 transcript yields **no offline oracle at all**. The only way to test a password
-guess is to run a fresh exchange with the honest server — an *online* guess it
+guess is to run a fresh exchange with the honest server, an *online* guess it
 can throttle and lock. That single property is what makes a weak, memorable
 password safe, and it is precisely what this construction lacks.
 
@@ -136,7 +136,7 @@ From `poorman_handshake/asymmetric/`:
 4. The session key is `secret_a XOR secret_b` (for `HalfHandShake`, only the
    sender's secret is used).
 
-### Why this is safe — as far as it goes
+### Why this is safe: as far as it goes
 
 The paddings are the modern, sound ones: OAEP for encryption and PSS for
 signing, not textbook RSA or PKCS#1 v1.5. Signing the ciphertext gives
@@ -146,18 +146,18 @@ key, so a single misbehaving side cannot force a known key.
 
 ### Why it is not safe enough
 
-1. **No forward secrecy — this is the serious one.** The session secret is
+1. **No forward secrecy: this is the serious one.** The session secret is
    *RSA key-transported* under a **long-term** key. An attacker who records
    handshakes today and later obtains a node's RSA private key decrypts the
    transported secret, and therefore every past session that key established.
    An ephemeral Diffie-Hellman exchange (e.g. X25519) makes past sessions
-   unrecoverable even given the long-term key; RSA key transport structurally
-   cannot. On its own this disqualifies the RSA path as a modern transport
+   unrecoverable even given the long-term key. RSA key transport structurally
+   cannot do this. On its own this disqualifies the RSA path as a modern transport
    bootstrap.
 
 2. **Authentication is entirely on the caller.** The signature only helps if you
    already hold the peer's *authentic* public key. First contact with an
-   unauthenticated key is a MITM waiting to happen — the repo's own
+   unauthenticated key is a MITM waiting to happen. The repo's own
    `examples/simple_mitm.py` and `examples/tofu_mitm.py` demonstrate exactly
    this. TOFU-pinning or out-of-band pre-distribution is left to the user, and
    nothing in the handshake binds identities into the transcript.
@@ -167,13 +167,13 @@ key, so a single misbehaving side cannot force a known key.
    future slip in decrypt-error handling reintroduces padding-oracle risk that
    an ECDH exchange never has.
 
-4. **`HalfHandShake` is weaker still** — only the sender contributes, so the
-   sender fully determines the key; there is no mutual randomness.
+4. **`HalfHandShake` is weaker still.** Only the sender contributes, so the
+   sender fully determines the key. There is no mutual randomness.
 
 ## The cautionary tale: why this is a case study in *not* rolling your own crypto
 
 None of the individual pieces here are broken. SHA-256, PBKDF2, RSA-OAEP,
-RSA-PSS, hSub addressing — all are fine, well-understood primitives used within
+RSA-PSS, hSub addressing: all are fine, well-understood primitives used within
 their specs. **The vulnerability lives entirely in the composition**, and that
 is almost always where do-it-yourself cryptography fails. A few lessons fall
 straight out of the analysis above:
@@ -183,27 +183,27 @@ straight out of the analysis above:
   the wire, it must be protected.* But a *verifiable image* of the secret
   crossing the wire is enough to break it, because the attacker's job is to
   **test guesses**, not to read the secret. Confidentiality of the bytes and
-  unguessability of the secret are different properties; this construction has
+  unguessability of the secret are different properties. This construction has
   the first and lacks the second.
 
 - **The name was the tell.** `protocol.md` used to call the password path
-  "PAKE-style." It has the *silhouette* of a PAKE — shared password in, shared
-  key out, password never transmitted — without the one property that *defines*
+  "PAKE-style." It has the *silhouette* of a PAKE (shared password in, shared
+  key out, password never transmitted) without the one property that *defines*
   a PAKE: no offline dictionary attack. Building something that resembles a
   known primitive is not the same as building the primitive, and "-style" or
   "-inspired" in a crypto description is a reliable warning sign that a security
   property was approximated by shape rather than achieved.
 
 - **It passes every test except the adversary.** Both sides derive the same
-  key; the unit tests are green; the demo works. Correctness tests confirm that
-  *honest* parties agree — they say nothing about what a *dishonest* party can
+  key, the unit tests are green, and the demo works. Correctness tests confirm that
+  *honest* parties agree. They say nothing about what a *dishonest* party can
   do. Cryptographic security is a property against an adversary you have to
   explicitly model, and a hand-built protocol ships with neither a threat model
   nor a proof, so the gap only surfaces under an attacker you did not think of
   (here: offline guessing, and future key compromise).
 
 - **Reusing good tech in the wrong context is still a bug.** hSub is *correct*
-  remailer technology, and HiveMind's Usenet transport still uses it correctly —
+  remailer technology, and HiveMind's Usenet transport still uses it correctly,
   as an unlinkable label with a separate PGP layer doing confidentiality. The
   error was carrying that same construction onto a live link where nothing sits
   underneath it, so a mechanism designed to *address* mail was asked to
@@ -211,9 +211,9 @@ straight out of the analysis above:
 
 - **"Use vetted crypto" means vetted *protocols*, not just vetted ciphers.** The
   fix is not "use a library's AES instead of writing AES." It is: **use a
-  reviewed key-exchange protocol** — Noise, TLS 1.3, or a real asymmetric PAKE
-  such as OPAQUE or SPAKE2 — instead of assembling your own handshake out of
-  hashes and RSA calls. A protocol comes with a threat model and a proof; a
+  reviewed key-exchange protocol**, such as Noise, TLS 1.3, or a real asymmetric PAKE
+  like OPAQUE or SPAKE2, instead of assembling your own handshake out of
+  hashes and RSA calls. A protocol comes with a threat model and a proof. A
   hand-wired handshake comes with neither, and this page is what the difference
   looks like.
 
@@ -224,21 +224,24 @@ HiveMind protocol **v3** moves the shared password into the **PSK slot of
 for the pre-provisioned-keys case. That single, reviewed pattern supplies the
 four properties this bespoke handshake lacked, all at once:
 
-- the wire messages stop being a checkable image of the password → **offline-
-  dictionary resistance** (the real PAKE property);
-- an ephemeral X25519 exchange → **forward secrecy**;
-- mutual static-key authentication → **MITM resistance**;
-- the negotiated parameters mixed into the handshake hash → **transcript /
+- the wire messages stop being a checkable image of the password, giving **offline-
+  dictionary resistance** (the real PAKE property)
+- an ephemeral X25519 exchange leads to **forward secrecy**
+- mutual static-key authentication leads to **MITM resistance**
+- the negotiated parameters mixed into the handshake hash give **transcript /
   downgrade binding**.
 
 Until you are on v3, if you must use this library:
 
 - **Use a high-entropy random access key (≥128 bits), never a human
   passphrase.** This is the one change that actually neutralizes the password
-  path's offline-dictionary weakness — there is nothing to enumerate.
+  path's offline-dictionary weakness. There is nothing to enumerate.
 - Treat the RSA path as providing **no forward secrecy**, and **validate public
-  keys out of band** (TOFU-pin or pre-distribute); never accept an unauthenticated
+  keys out of band** (TOFU-pin or pre-distribute). Never accept an unauthenticated
   key on first contact in a hostile setting.
 - Always wrap the derived `secret` in authenticated encryption (AES-GCM,
-  ChaCha20-Poly1305) — the handshake is a bootstrap, not a transport.
+  ChaCha20-Poly1305). The handshake is a bootstrap, not a transport.
 - Prefer the v3 Noise handshake wherever it is available.
+
+---
+[← Protocol reference](protocol.md) · [Home](../README.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md in Simplified Technical English for clarity: shorter sentences, active voice, no em dashes or semicolons, banned marketing/slop words removed. Adds a relative-link navigation footer to docs/protocol.md and docs/security.md. Every fact, code block, and citation is unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security guidance to recommend Noise as the preferred handshake.
  * Clarified legacy password-handshake risks, including offline password attacks.
  * Documented `HalfHandShake` usage, Noise options, and `remote_pubkey`.
  * Clarified RSA limitations, including its lack of forward secrecy.
  * Improved protocol terminology, formatting, navigation, and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->